### PR TITLE
Fixed SAFARI breaking inline-block

### DIFF
--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -29,8 +29,9 @@ figcaption{
 }
 
 .caps{
+  text-transform: lowercase;
   font-variant: small-caps;
-  font-variant-caps: all-small-caps;
+  // font-variant-caps: all-small-caps; // This fails hard in SAFARI
 }
 
 .italic{font-style: italic;}


### PR DESCRIPTION
SAFARI failed inline-blocking all-small-caps, so I used text-transform:
lowercase + small-caps which does the same